### PR TITLE
SftpClient hotfix

### DIFF
--- a/documentation/test-configs/baseline-nodsp-slot01_config.json
+++ b/documentation/test-configs/baseline-nodsp-slot01_config.json
@@ -1,6 +1,6 @@
 {
   "ServerInfo": {
-    "Host": "192.168.1.251",
+    "Host": "10.8.113.152",
     "User": "svc_crestron",
     "Key": "sftp-crestron"
   },

--- a/pkd-common-utils/NetComs/BasicFtpClient.cs
+++ b/pkd-common-utils/NetComs/BasicFtpClient.cs
@@ -1,9 +1,7 @@
-﻿using Crestron.SimplSharp.Ssh;
+﻿
 using pkd_common_utils.Logging;
 using pkd_common_utils.Validation;
-using FileMode = Crestron.SimplSharp.CrestronIO.FileMode;
-using FileStream = Crestron.SimplSharp.CrestronIO.FileStream;
-using IAsyncResult = Crestron.SimplSharp.CrestronIO.IAsyncResult;
+using Renci.SshNet;
 
 namespace pkd_common_utils.NetComs
 {

--- a/pkd-common-utils/pkd-common-utils.csproj
+++ b/pkd-common-utils/pkd-common-utils.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Crestron.SimplSharp.SDK.ProgramLibrary" Version="2.21.90" />
+    <PackageReference Include="SSH.NET" Version="2024.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkd-config-service/ConfigurationService.cs
+++ b/pkd-config-service/ConfigurationService.cs
@@ -1,11 +1,11 @@
 ﻿using System.Text;
 using Crestron.SimplSharp;
-using Crestron.SimplSharp.Ssh;
 using Crestron.SimplSharpPro;
 using pkd_common_utils.FileOps;
 using pkd_common_utils.Logging;
 using pkd_common_utils.NetComs;
 using pkd_domain_service;
+using Renci.SshNet;
 
 namespace pkd_config_service
 {


### PR DESCRIPTION
- Replaced the Crestron sandbox SftpClient with SSH.Net. This fixes a threading issue in the Crestron sandbox libraries.